### PR TITLE
Fix linter error message in iOS app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERROR<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="it">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
Remove debugging message 'THIS SHOULD BE A LINTER ERROR' that was appearing in the iOS app.