### PR TITLE
Fix PWA GitHub Pages hosting issue

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,12 @@
   "name": "Boiler Calculator PWA",
   "short_name": "Boiler Calc",
   "description": "Cinque calcolatori specializzati per calcoli termici e matematici",
-  "start_url": "/",
+  "start_url": "/pwa_prova/",
   "display": "fullscreen",
   "orientation": "portrait",
   "theme_color": "#2c3e50",
   "background_color": "#667eea",
-  "scope": "/",
+  "scope": "/pwa_prova/",
   "lang": "it",
   "categories": ["utilities", "productivity"],
   "icons": [
@@ -34,7 +34,7 @@
       "name": "Calcola",
       "short_name": "Calcola",
       "description": "Apri la calcolatrice",
-      "url": "/",
+      "url": "/pwa_prova/",
       "icons": [
         {
           "src": "icon-192x192.png",

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 const CACHE_NAME = 'calcolatrice-pwa-v1';
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/manifest.json'
+  '/pwa_prova/',
+  '/pwa_prova/index.html',
+  '/pwa_prova/manifest.json'
 ];
 
 // Install event - cache resources


### PR DESCRIPTION
Update PWA paths in manifest and service worker to fix 404 error when launched from home screen on GitHub Pages.

The PWA's `start_url` and `scope` in `manifest.json`, and cached URLs in `sw.js`, were incorrectly set to the root (`/`) instead of the repository-specific path (`/pwa_prova/`) required for GitHub Pages deployments. This caused a 404 error when the PWA was launched as a standalone application.