### PR TITLE
Check old website version

### DIFF
--- a/cache_fix_summary.md
+++ b/cache_fix_summary.md
@@ -1,0 +1,93 @@
+# 🔮 Astrology PWA Cache Issue - Fixed
+
+## 📋 **Problem Identified**
+
+You were seeing the **old version** of your astrology calculator website due to **Service Worker caching**. Your PWA has aggressive caching enabled with a "Cache First" strategy.
+
+## ✅ **Solutions Implemented**
+
+### 1. **Service Worker Cache Version Updated**
+- **Changed from**: `astro-calc-v1.0.0`
+- **Changed to**: `astro-calc-v1.0.1`
+- **Result**: This forces the Service Worker to clear old cached files and fetch new ones
+
+### 2. **Changes Deployed**
+- Updated service worker has been committed and pushed to GitHub
+- Repository: `stramazzo/pwa_prova`
+- The deployment should automatically update with the new cache version
+
+## 🌐 **Possible Website URLs**
+
+Your astrology calculator PWA might be hosted at one of these URLs:
+
+### **Most Likely:**
+- `https://stramazzo.github.io/pwa_prova/`
+- `https://stramazzo.github.io/pwa_prova/index.html`
+
+### **Alternative Hosting:**
+- Custom domain (if configured)
+- Netlify, Vercel, or other hosting platform
+
+## 🛠️ **How to Clear Cache Manually**
+
+If you're still seeing the old website, try these steps:
+
+### **Method 1: Hard Refresh**
+- **Windows/Linux**: `Ctrl + F5` or `Ctrl + Shift + R`
+- **Mac**: `Cmd + Shift + R`
+
+### **Method 2: Clear Cache in Browser**
+1. Open Developer Tools (`F12`)
+2. Go to **Application** tab
+3. Click **Storage** → **Clear storage**
+4. Click **Clear site data**
+
+### **Method 3: Clear Service Worker**
+1. Open Developer Tools (`F12`)
+2. Go to **Application** tab → **Service Workers**
+3. Find your service worker
+4. Click **Unregister**
+5. Refresh the page
+
+### **Method 4: Incognito/Private Mode**
+- Open the website in incognito/private browsing mode
+- This bypasses all caches
+
+## 🔍 **How to Verify the Fix**
+
+1. **Check Service Worker Version**:
+   - Open Developer Tools → Application → Service Workers
+   - Look for cache name `astro-calc-v1.0.1`
+
+2. **Check Network Tab**:
+   - Open Developer Tools → Network
+   - Refresh the page
+   - Files should show "from network" instead of "from cache"
+
+3. **Check Console**:
+   - Look for: `Service Worker: Deleting old cache astro-calc-v1.0.0`
+
+## 📱 **PWA Installation Update**
+
+If you have the app installed as a PWA:
+1. **Uninstall** the current PWA
+2. **Clear** all browser data for the site
+3. **Reinstall** the PWA with the updated version
+
+## 🚀 **Future Cache Updates**
+
+To force cache updates in the future:
+1. Update the `CACHE_NAME` version in `sw.js`
+2. Commit and push changes
+3. The Service Worker will automatically clean old caches
+
+## 📝 **Technical Details**
+
+- **Service Worker File**: `sw.js`
+- **Caching Strategy**: Cache First for static files
+- **Cache Names**: `astro-calc-v1.0.x` and `astro-calc-v1.0.x-api`
+- **Automatic Cleanup**: Old caches are automatically deleted when version changes
+
+---
+
+**Status**: ✅ **FIXED** - Service Worker cache version updated and deployed


### PR DESCRIPTION
Increment Service Worker cache version and add a summary document to resolve stale website content.

The Service Worker was aggressively caching old files, preventing the latest website version from being displayed. The cache version increment forces the Service Worker to clear old caches. A `cache_fix_summary.md` file was also added to explain the fix and provide manual troubleshooting steps for the user.